### PR TITLE
frontend: prevent sidebar text selection

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -81,6 +81,7 @@
 		let popup: maplibregl.Popup | null = null;
 		const mapCanvas = map.getCanvas();
 
+		// Prevent unintended sidebar text selection when shift + arrow keys are used for map navigation
 		const preventMapSelection = (event: KeyboardEvent) => {
 			if (event.altKey || event.ctrlKey || event.metaKey || !event.shiftKey) return;
 			if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -79,6 +79,15 @@
 		if (!map) return;
 
 		let popup: maplibregl.Popup | null = null;
+		const mapCanvas = map.getCanvas();
+
+		const preventMapSelection = (event: KeyboardEvent) => {
+			if (event.altKey || event.ctrlKey || event.metaKey || !event.shiftKey) return;
+			if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+
+			// MapLibre handles the camera change, but does not suppress the browser's text selection.
+			event.preventDefault();
+		};
 
 		const handleRouteClick = (
 			e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }
@@ -126,6 +135,7 @@
 		map.on('mouseleave', 'RouteHitArea', resetCursor);
 		map.on('mouseenter', 'Route', setCursorPointer);
 		map.on('mouseleave', 'Route', resetCursor);
+		mapCanvas.addEventListener('keydown', preventMapSelection);
 
 		return () => {
 			map!.off('click', 'RouteHitArea', handleRouteClick);
@@ -133,6 +143,7 @@
 			map!.off('mouseleave', 'RouteHitArea', resetCursor);
 			map!.off('mouseenter', 'Route', setCursorPointer);
 			map!.off('mouseleave', 'Route', resetCursor);
+			mapCanvas.removeEventListener('keydown', preventMapSelection);
 			popup?.remove();
 		};
 	});


### PR DESCRIPTION
Adds a keydown handler on the MapLibre canvas that calls preventDefault() for Shift+Arrow map controls. MapLibre already handles the pitch/rotate action, but it wasn’t suppressing the browser’s native text-selection behavior for those keys, which is why the sidebar text was getting selected.